### PR TITLE
Prevent s3 tests for importing google gs dependencies

### DIFF
--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -3,25 +3,25 @@ package auth
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/viant/afs/option"
 	"github.com/viant/afs/storage"
-	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
-	"io/ioutil"
-	"os"
 )
 
-//JWTProvider represetns JWT based auth provider
+// JWTProvider represents JWT based auth provider
 type JWTProvider interface {
 	JWTConfig(scopes ...string) (config *jwt.Config, projectID string, err error)
 }
 
-//JwtConfig represents google service account secrets
+// JwtConfig represents google service account secrets
 type JwtConfig struct {
-	//google cloud credential
+	// google cloud credential
 	ClientEmail             string `json:"client_email,omitempty"`
-	TokenURL                string `json:"token_uri,omitempty"`
+	TokenURL                string `json:"token_url,omitempty"`
 	PrivateKey              string `json:"private_key,omitempty"`
 	PrivateKeyID            string `json:"private_key_id,omitempty"`
 	ProjectID               string `json:"project_id,omitempty"`
@@ -32,7 +32,7 @@ type JwtConfig struct {
 	jwtClientConfig         *jwt.Config
 }
 
-//JWTConfig returns new JWT config for supplied scopes
+// JWTConfig returns new JWT config for supplied scopes
 func (c *JwtConfig) JWTConfig(scopes ...string) (config *jwt.Config, projectID string, err error) {
 	if c.jwtClientConfig != nil {
 		return c.jwtClientConfig, c.ProjectID, nil
@@ -46,13 +46,13 @@ func (c *JwtConfig) JWTConfig(scopes ...string) (config *jwt.Config, projectID s
 		TokenURL:     c.TokenURL,
 	}
 	if result.TokenURL == "" {
-		result.TokenURL = google.JWTTokenURL
+		result.TokenURL = "https://oauth2.googleapis.com/token"
 	}
 	c.jwtClientConfig = result
 	return result, c.ProjectID, nil
 }
 
-//NewJwtConfig returns new secrets from location
+// NewJwtConfig returns new secrets from location
 func NewJwtConfig(options ...storage.Option) (*JwtConfig, error) {
 	location := &option.Location{}
 	var JSONPayload = make([]byte, 0)
@@ -67,7 +67,7 @@ func NewJwtConfig(options ...storage.Option) (*JwtConfig, error) {
 			return nil, errors.Wrap(err, "failed to open auth config")
 		}
 		defer func() { _ = file.Close() }()
-		if JSONPayload, err = ioutil.ReadAll(file); err != nil {
+		if JSONPayload, err = io.ReadAll(file); err != nil {
 			return nil, err
 		}
 	}

--- a/s3/example_test.go
+++ b/s3/example_test.go
@@ -3,17 +3,17 @@ package s3_test
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/viant/afs"
-	"github.com/viant/afs/option"
-	"github.com/viant/afsc/auth"
-	"github.com/viant/afsc/gs"
-	"github.com/viant/afsc/s3"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/viant/afs"
+	"github.com/viant/afs/option"
+	"github.com/viant/afsc/auth"
+	"github.com/viant/afsc/s3"
 )
 
 func ExampleAfsService() {
@@ -33,7 +33,7 @@ func ExampleAfsService() {
 			log.Fatal(err)
 		}
 		defer reader.Close()
-		data, err := ioutil.ReadAll(reader)
+		data, err := io.ReadAll(reader)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -42,25 +42,25 @@ func ExampleAfsService() {
 }
 
 func ExampleNew() {
-	service := gs.New()
+	service := s3.New()
 	ctx := context.Background()
 	reader, err := service.OpenURL(ctx, "s3://my-bucket/folder/asset")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer reader.Close()
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		log.Fatal(err)
 	}
 	fmt.Printf("data: %s\n", data)
 }
 
-//Example_Storager storager usage example (uses path rather then URLs)
+// Example_Storager storager usage example (uses path rather then URLs)
 func Example_Storager() {
 
 	ctx := context.Background()
-	service, err := gs.NewStorager(ctx, "s3://myBucket/")
+	service, err := s3.NewStorager(ctx, "s3://myBucket/")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func Example_Storager() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	fmt.Printf("data: %s\n", data)
 
 	has, _ := service.Exists(ctx, location)
@@ -102,11 +102,11 @@ func ExampleNewAuthConfig() {
 	}
 
 	ctx := context.Background()
-	//add default import _ "github.com/viant/afsc/s3"
+	// add default import _ "github.com/viant/afsc/s3"
 
 	service := afs.New()
 	reader, err := service.OpenURL(ctx, "s3://my-bucket/myfolder/asset.txt", authConfig)
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -116,11 +116,11 @@ func ExampleNewAuthConfig() {
 
 func ExampleAwsConfig() {
 	var awsConfig *aws.Config
-	//get config
+	// get config
 	ctx := context.Background()
 	service := afs.New()
 	reader, err := service.OpenURL(ctx, "s3://my-bucket/myfolder/asset.txt", awsConfig)
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -139,7 +139,7 @@ func ExampleNewCustomKey() {
 		log.Fatal(err)
 	}
 	reader, err := service.OpenURL(ctx, "s3://mybucket/folder/secret1.txt", customKey)
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/s3/manager.go
+++ b/s3/manager.go
@@ -23,7 +23,7 @@ type manager struct {
 
 func (m *manager) provider(ctx context.Context, baseURL string, options ...storage.Option) (storage.Storager, error) {
 	options = m.Options(options)
-	return newStorager(ctx, baseURL, options...)
+	return NewStorager(ctx, baseURL, options...)
 }
 
 func (m *manager) copyInMemory(ctx context.Context, sourceURL, destURL string, options []storage.Option) error {

--- a/s3/storager.go
+++ b/s3/storager.go
@@ -2,6 +2,10 @@ package s3
 
 import (
 	"context"
+	"log"
+	"os"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -10,9 +14,6 @@ import (
 	"github.com/viant/afs/storage"
 	"github.com/viant/afs/url"
 	"github.com/viant/afsc/logger"
-	"log"
-	"os"
-	"time"
 )
 
 const (
@@ -116,7 +117,7 @@ func getAwsConfig(options []storage.Option) (config *aws.Config, err error) {
 	return config, err
 }
 
-func newStorager(ctx context.Context, baseURL string, options ...storage.Option) (*storager, error) {
+func NewStorager(ctx context.Context, baseURL string, options ...storage.Option) (*storager, error) {
 	result := &storager{
 		bucket: url.Host(baseURL),
 	}

--- a/s3/storager_test.go
+++ b/s3/storager_test.go
@@ -34,6 +34,6 @@ func NewTestStorager(ctx context.Context, bucket string) (storage.Storager, erro
 	if err != nil {
 		return nil, err
 	}
-	return newStorager(ctx, fmt.Sprintf("s3://%s", bucket), authConfig)
+	return NewStorager(ctx, fmt.Sprintf("s3://%s", bucket), authConfig)
 
 }


### PR DESCRIPTION
See https://github.com/viant/afsc/issues/6, this should hopefully prevent a load of google indirect dependencies coming into projects that only use AWS s3 functionality.

Tested to work with replace github.com/viant/afsc => github.com/knights-analytics/afsc v0.0.0-20240419150436-7b7def176954 , google dependencies disappear and library appears to still work for me
