### PR TITLE
Fix leading slashes in keys

### DIFF
--- a/s3/delete.go
+++ b/s3/delete.go
@@ -11,9 +11,15 @@ import (
 
 // Delete removes an resource
 func (s *Storager) Delete(ctx context.Context, location string, options ...storage.Option) error {
+
+	// In SDK v2, DeleteObject does not handle leading slashes, so remove them here
+	deleteLocation := location
+	if len(deleteLocation) > 0 && deleteLocation[0] == '/' {
+		deleteLocation = deleteLocation[1:]
+	}
 	_, err := s.Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: &s.bucket,
-		Key:    &location,
+		Key:    &deleteLocation,
 	})
 	if isNotFound(err) {
 		objectKind := &option.ObjectKind{}

--- a/s3/open.go
+++ b/s3/open.go
@@ -19,6 +19,13 @@ import (
 
 // Open return content reader and hash values if md5 or crc option is supplied or error
 func (s *Storager) Open(ctx context.Context, location string, options ...storage.Option) (io.ReadCloser, error) {
+
+	// In SDK v2, multiple functions do not handle leading slashes, so remove them here
+	parsedLocation := location
+	if len(parsedLocation) > 0 && parsedLocation[0] == '/' {
+		parsedLocation = parsedLocation[1:]
+	}
+
 	started := time.Now()
 	defer func() {
 		s.logF("s3:Open %v %s\n", location, time.Since(started))
@@ -30,7 +37,7 @@ func (s *Storager) Open(ctx context.Context, location string, options ...storage
 	option.Assign(options, &key, &stream)
 	input := &s3.GetObjectInput{
 		Bucket: &s.bucket,
-		Key:    &location,
+		Key:    &parsedLocation,
 	}
 
 	if len(key.Key) > 0 {


### PR DESCRIPTION
These leading slashes have always been present, come from url parsing in the afs library.  However it seems aws sdk v2 does not like them in open and delete, but it is fine in list and other operations.  So i just remove them if present here.