### PR TITLE
fix: bugs in copying folders from s3 to s3

### DIFF
--- a/s3/const.go
+++ b/s3/const.go
@@ -5,4 +5,5 @@ const (
 	contentMD5MetaKey         = "ContentMD5"
 	noSuchKeyMessage          = "NoSuchKey"
 	doesNotExistsMessage      = "does not exist"
+	notFoundMessage           = "NotFound"
 )

--- a/s3/copy.go
+++ b/s3/copy.go
@@ -36,7 +36,7 @@ func (s *Storager) Copy(ctx context.Context, sourcePath, destBucket, destPath st
 		}
 		for i := 1; i < len(infoList); i++ {
 			name := infoList[i].Name()
-			if err = s.Move(ctx, path.Join(sourcePath, name), destBucket, path.Join(destPath, name)); err != nil {
+			if err = s.Copy(ctx, path.Join(sourcePath, name), destBucket, path.Join(destPath, name)); err != nil {
 				return err
 			}
 		}

--- a/s3/helper.go
+++ b/s3/helper.go
@@ -30,5 +30,5 @@ func isNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), noSuchKeyMessage) || strings.Contains(err.Error(), doesNotExistsMessage)
+	return strings.Contains(err.Error(), noSuchKeyMessage) || strings.Contains(err.Error(), doesNotExistsMessage) || strings.Contains(err.Error(), notFoundMessage)
 }


### PR DESCRIPTION
Copying folders from s3 to s3 wasn't working because the error matching for isNotFound wasn't firing correctly (api now returns "NotFound"). Moreover the Copy function was using s.Move rather than s.Copy.
This MR fixes these two points.